### PR TITLE
4.2 extension support

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,58 @@
+schema_version = "1.0.0"
+
+id = "node_relax"
+version = "1.0.0"
+name = "Node Relax"
+tagline = "Tool for arranging nodes easier"
+maintainer = "Shahzod Boyhonov (Specoolar)"
+type = "add-on"
+
+# Optional: add-ons can list which resources they will require:
+# * "files" (for access of any filesystem operations)
+# * "network" (for internet access)
+# * "clipboard" (to read and/or write the system clipboard)
+# * "camera" (to capture photos and videos)
+# * "microphone" (to capture audio)
+# permissions = ["files", "network"]
+
+# Optional link to documentation, support, source files, etc
+website = "https://github.com/specoolar/NodeRelax-Blender-Addon"
+
+# Optional list defined by Blender and server, see:
+# https://docs.blender.org/manual/en/dev/extensions/tags.html
+tags = ["Node"]
+
+blender_version_min = "2.92.0"
+# Optional: maximum supported Blender version
+# blender_version_max = "5.1.0"
+
+# License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
+# https://docs.blender.org/manual/en/dev/extensions/licenses.html
+license = [
+  "SPDX:GPL-3.0-or-later",
+]
+# Optional: required by some licenses.
+# copyright = [
+#   "2002-2024 Developer Name",
+#   "1998 Company Name",
+# ]
+
+# Optional list of supported platforms. If omitted, the extension will be available in all operating systems.
+# platforms = ["windows-amd64", "macos-arm64", "linux-x86_64"]
+# Other supported platforms: "windows-arm64", "macos-x86_64"
+
+# Optional: bundle 3rd party Python modules.
+# https://docs.blender.org/manual/en/dev/extensions/python_wheels.html
+# wheels = [
+#   "./wheels/hexdump-3.3-py3-none-any.whl",
+#   "./wheels/jsmin-3.0.1-py3-none-any.whl"
+# ]
+
+# Optional: build setting.
+# https://docs.blender.org/manual/en/dev/extensions/command_line_arguments.html#command-line-args-extension-build
+[build]
+paths_exclude_pattern = [
+    "/.git/",
+    "__pycache__/",
+    ".idea",
+]


### PR DESCRIPTION
* blender_manifest.toml added so Blender 4.2 can recognize add-on as an extension

Did a smokescreen test in 4.2, no issues from what I can see with the rest of the code as-is.